### PR TITLE
Add support for using shared S3 paths as EMR inputs

### DIFF
--- a/lib/pipely/build/s3_path_builder.rb
+++ b/lib/pipely/build/s3_path_builder.rb
@@ -41,6 +41,10 @@ module Pipely
         "s3://#{@assets_bucket}/#{@s3prefix}/shared/#{START_DATE}"
       end
 
+      def s3n_shared_asset_prefix
+        "s3n://#{@assets_bucket}/#{@s3prefix}/shared/#{START_DATE}"
+      end
+
       def bucket_relative_s3_asset_prefix
         "#{@s3prefix}/#{START_TIME}"
       end
@@ -53,6 +57,7 @@ module Pipely
           :s3_asset_prefix => s3_asset_prefix,
           :s3n_asset_prefix => s3n_asset_prefix,
           :s3_shared_asset_prefix => s3_shared_asset_prefix,
+          :s3n_shared_asset_prefix => s3n_shared_asset_prefix,
           :bucket_relative_s3_asset_prefix => bucket_relative_s3_asset_prefix,
         }
       end

--- a/lib/pipely/build/template_helpers.rb
+++ b/lib/pipely/build/template_helpers.rb
@@ -13,6 +13,10 @@ module Pipely
         "#{s3n_asset_prefix if '/' == path[0]}#{path}"
       end
 
+      def s3n_shared_asset_path(path)
+        "#{s3n_shared_asset_prefix if '/' == path[0]}#{path}"
+      end
+
       def s3n_step_path(path)
         "#{s3n_step_prefix if '/' == path[0]}#{path}"
       end
@@ -21,7 +25,14 @@ module Pipely
         parts = [ '/home/hadoop/contrib/streaming/hadoop-streaming.jar' ]
 
         Array(options[:input]).each do |input|
-          parts += [ '-input', s3n_asset_path(input) ]
+          # HACK: We want a consistent namespace for our S3 paths, but in order
+          # to support existing pipelines while we transition we need to allow
+          # the client to specify which form its input path follows.
+          if options[:input_shared]
+            parts += [ '-input', s3n_shared_asset_path(input) ]
+          else
+            parts += [ '-input', s3n_asset_path(input) ]
+          end
         end
 
         Array(options[:output]).each do |output|

--- a/lib/pipely/version.rb
+++ b/lib/pipely/version.rb
@@ -1,3 +1,3 @@
 module Pipely
-  VERSION = "0.4.4" unless defined?(::Pipely::VERSION)
+  VERSION = "0.4.5" unless defined?(::Pipely::VERSION)
 end

--- a/spec/lib/pipely/build/s3_path_builder_spec.rb
+++ b/spec/lib/pipely/build/s3_path_builder_spec.rb
@@ -31,6 +31,14 @@ describe Pipely::Build::S3PathBuilder do
     should eq("s3n://asset-bucket/run-prefix/\#{format(@scheduledStartTime,'YYYY-MM-dd_HHmmss')}")
   }
 
+  its(:s3_shared_asset_prefix) {
+    should eq("s3://asset-bucket/run-prefix/shared/\#{format(@scheduledStartTime,'YYYY-MM-dd')}")
+  }
+
+  its(:s3n_shared_asset_prefix) {
+    should eq("s3n://asset-bucket/run-prefix/shared/\#{format(@scheduledStartTime,'YYYY-MM-dd')}")
+  }
+
   describe "#to_hash" do
     it 'includes the necessary keys for supplying config to a Template' do
       expect(subject.to_hash.keys).to match_array([
@@ -40,6 +48,7 @@ describe Pipely::Build::S3PathBuilder do
         :s3_asset_prefix,
         :s3n_asset_prefix,
         :s3_shared_asset_prefix,
+        :s3n_shared_asset_prefix,
         :bucket_relative_s3_asset_prefix,
       ])
     end


### PR DESCRIPTION
@accardi - This should let us get around the problem of using S3 paths in the "shared" format as inputs to EMR jobs.
