### PR TITLE
use SecureRandom to generate pipeline unique ids

### DIFF
--- a/lib/pipely/deploy/client.rb
+++ b/lib/pipely/deploy/client.rb
@@ -14,7 +14,7 @@ require 'fog'
 require 'aws-sdk'
 require 'logger'
 require 'tempfile'
-require 'uuidtools'
+require 'securerandom'
 
 module Pipely
   module Deploy
@@ -85,7 +85,7 @@ module Pipely
       def create_pipeline(pipeline_name, definition, tags={})
         definition_objects = JSON.parse(definition)['objects']
 
-        unique_id = UUIDTools::UUID.random_create
+        unique_id = SecureRandom.uuid
 
         created_pipeline = @data_pipelines.pipelines.create(
           unique_id: unique_id,

--- a/pipely.gemspec
+++ b/pipely.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.add_dependency "fog", "~>1.23.0"
   s.add_dependency "aws-sdk", "~>1.48"
   s.add_dependency "unf"
-  s.add_dependency "uuidtools"
   s.add_dependency "activesupport"
   s.add_dependency "erubis"
   s.add_development_dependency "rspec", "~>2.14.0"


### PR DESCRIPTION
@kbarrette @peakxu 

This avoids depending on the uuidtools gem, instead favoring Ruby's stdlib.  Additionally, this causes us to pass a string into Fog, instead of the UUID object returned by UUIDTools.  This fixes a bug that arises when active_support/core_ext is loaded, overriding fog-json's #to_json implementation for many objects, including UUID.

Repro: https://gist.github.com/409287dfdff6355a8a99
