### PR TITLE
use Gem::RemoteFetcher to download from rubygems

### DIFF
--- a/lib/pipely/bundler/gem_packager.rb
+++ b/lib/pipely/bundler/gem_packager.rb
@@ -1,5 +1,5 @@
 require 'fileutils'
-require 'excon'
+require 'rubygems/remote_fetcher'
 
 module Pipely
   module Bundler
@@ -100,19 +100,12 @@ module Pipely
              "distrubtion, for more details see LINK"
 
         ruby_gem_url = "https://rubygems.org/downloads/#{gem_file_name}"
-        response = Excon.get( ruby_gem_url, {
-          middlewares: Excon.defaults[:middlewares] +
-                       [Excon::Middleware::RedirectFollower]
-        })
 
-        if response.status == 200
-          File.open(vendored_gem, 'w') { |file| file.write( response.body ) }
-          return vendored_gem
-        else
-          raise GemFetchError.new(
-            "Failed to find #{gem_file_name} at rubygems, recieved
-            #{response.status} with #{response.body}" )
-        end
+        fetcher = Gem::RemoteFetcher.new
+        gem_data = fetcher.fetch_path(ruby_gem_url)
+        IO.binwrite(vendored_gem, gem_data)
+
+        vendored_gem
       end
     end
   end

--- a/spec/lib/pipely/bundler/gem_packager_spec.rb
+++ b/spec/lib/pipely/bundler/gem_packager_spec.rb
@@ -64,29 +64,15 @@ describe Pipely::Bundler::GemPackager do
         end
 
         it "downloads from rubygems" do
-          response = double(:response, status: 200, body: 'im a gem')
-          expect(Excon).to receive(:get).with(
-            "https://rubygems.org/downloads/test-0.0.1.gem", anything())
-            .and_return(response)
+          remote_fetcher = double(:remote_fetcher)
+          expect(Gem::RemoteFetcher).to receive(:new).and_return(remote_fetcher)
+          expect(remote_fetcher).to receive(:fetch_path).
+            with("https://rubygems.org/downloads/test-0.0.1.gem")
           expect(subject.package(gem_spec)).to eq(
             {"test"=>"vendor/test/test-0.0.1.gem"})
         end
       end
 
-      context "if source not available and not on rubygems" do
-        before do
-          allow(File).to receive(:directory?).with(gem_spec.gem_dir) { false }
-        end
-
-        it "raises" do
-          response = double(:response, status: 400, body: 'test')
-          expect(Excon).to receive(:get).with(
-            "https://rubygems.org/downloads/test-0.0.1.gem", anything())
-            .and_return(response)
-
-          expect { subject.package(gem_spec) }.to raise_error
-        end
-      end
     end
   end
 


### PR DESCRIPTION
@mattgillooly 

Fix the issue that downloads failed for valid urls to rubygems.
