### PR TITLE
support config for arbitrary environments

### DIFF
--- a/lib/pipely/build.rb
+++ b/lib/pipely/build.rb
@@ -4,6 +4,7 @@ require 'pipely/build/daily_scheduler'
 require 'pipely/build/right_now_scheduler'
 require 'pipely/build/s3_path_builder'
 require 'pipely/build/environment_config'
+require 'pathology'
 
 module Pipely
 
@@ -15,22 +16,7 @@ module Pipely
       env = environment.to_sym
       config = EnvironmentConfig.load(config_path, env)
 
-      case environment.to_sym
-      when :production
-        s3_prefix = "production/#{config[:namespace]}"
-        if config[:start_time]
-          # allow config to change pipelint start time
-          # TODO: all scheduling should be done through config before pipely 1.0
-          scheduler = DailyScheduler.new(config[:start_time])
-        else
-          scheduler = DailyScheduler.new
-        end
-      when :staging
-        s3_prefix = "staging/#{`whoami`.strip}/#{config[:namespace]}"
-        scheduler = RightNowScheduler.new
-      end
-
-      Definition.new(template, env, s3_prefix, scheduler, config)
+      Definition.new(template, env, config)
     end
 
   end

--- a/lib/pipely/build/daily_scheduler.rb
+++ b/lib/pipely/build/daily_scheduler.rb
@@ -6,7 +6,7 @@ module Pipely
     #
     class DailyScheduler
 
-      def initialize(start_time="11:00:00")
+      def initialize(start_time)
         @start_time = start_time
       end
 

--- a/lib/pipely/build/environment_config.rb
+++ b/lib/pipely/build/environment_config.rb
@@ -8,9 +8,28 @@ module Pipely
     #
     class EnvironmentConfig < Hash
 
+      # Continue supporting env-based defaults until pipely v1.0
+      ENV_DEFAULTS = {
+        production: {
+          s3_prefix: 'production/:namespace',
+          scheduler: 'daily',
+          start_time: '11:00:00',
+        },
+        staging: {
+          s3_prefix: 'staging/:whoami/:namespace',
+          scheduler: 'now',
+        }
+      }
+
       def self.load(filename, environment)
         raw = YAML.load_file(filename)[environment.to_s]
-        load_from_hash(raw)
+        config = load_from_hash(raw)
+
+        if defaults = ENV_DEFAULTS[environment.to_sym]
+          defaults.merge(config)
+        else
+          config
+        end
       end
 
       def self.load_from_hash(attributes)

--- a/pipely.gemspec
+++ b/pipely.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "unf"
   s.add_dependency "activesupport"
   s.add_dependency "erubis"
+  s.add_dependency 'pathology', '~> 0.1.0'
   s.add_development_dependency "rspec", "~>2.14.0"
   s.add_development_dependency "cane"
   s.add_development_dependency "timecop"

--- a/spec/lib/pipely/build/environment_config_spec.rb
+++ b/spec/lib/pipely/build/environment_config_spec.rb
@@ -1,0 +1,58 @@
+require 'pipely/build/environment_config'
+
+describe Pipely::Build::EnvironmentConfig do
+
+  describe '.load(filename, environment)' do
+    let(:filename) { 'path/to/config/yaml.yml' }
+
+    let(:config) do
+      YAML.load(<<-EOS)
+        my_env:
+          key: 'my_val'
+        production:
+          key: 'prod_val'
+        staging:
+          key: 'staging_val'
+      EOS
+    end
+
+    before do
+      allow(YAML).to receive(:load_file).with(filename) { config }
+    end
+
+    context 'given a custom environment' do
+      subject { described_class.load(filename, 'my_env') }
+
+      it 'loads config from a YAML file' do
+        expect(subject[:key]).to eq('my_val')
+      end
+    end
+
+    context 'given the "production" environment' do
+      subject { described_class.load(filename, 'production') }
+
+      it 'loads config from a YAML file' do
+        expect(subject[:key]).to eq('prod_val')
+      end
+
+      it 'supports legacy defaults' do
+        expect(subject[:s3_prefix]).to eq('production/:namespace')
+        expect(subject[:scheduler]).to eq('daily')
+      end
+    end
+
+    context 'given the "staging" environment' do
+      subject { described_class.load(filename, 'staging') }
+
+      it 'loads config from a YAML file' do
+        expect(subject[:key]).to eq('staging_val')
+      end
+
+      it 'supports legacy defaults' do
+        expect(subject[:s3_prefix]).to eq('staging/:whoami/:namespace')
+        expect(subject[:scheduler]).to eq('now')
+      end
+    end
+  end
+
+end

--- a/spec/lib/pipely/build_spec.rb
+++ b/spec/lib/pipely/build_spec.rb
@@ -1,3 +1,32 @@
+require 'pipely/build'
+
 describe Pipely::Build do
+
+  describe '.build_definition(template, environment, config_path)' do
+
+    let(:template) { double }
+    let(:environment) { 'production' }
+    let(:config_path) { 'path/to/config' }
+
+    let(:config) { double }
+
+    before do
+      allow(Pipely::Build::EnvironmentConfig).to receive(:load).
+        with(config_path, environment.to_sym).
+        and_return(config)
+    end
+
+    it 'builds a Definition' do
+      expect(
+        described_class.build_definition(template, environment, config_path)
+      ).to eq(
+        Pipely::Build::Definition.new(
+          template,
+          environment.to_sym,
+          config
+        )
+      )
+    end
+  end
 
 end


### PR DESCRIPTION
@peakxu - this enables, e.g. a "backfill" config environment, which will allow us to keep track of cluster size, etc we use for such.
