### PR TITLE
use first argument to rake tasks to override configured scheduler

### DIFF
--- a/lib/pipely/tasks/definition.rb
+++ b/lib/pipely/tasks/definition.rb
@@ -34,13 +34,20 @@ module Pipely
       def initialize(*args, &task_block)
         setup_ivars(args)
 
+        # First non-name parameter allows overriding the configured scheduler.
+        args.unshift(:scheduler)
+
         directory path
 
         desc "Generates the pipeline definition file"
-        task name => path do |_, task_args|
+        task name, *args do |_, task_args|
           RakeFileUtils.send(:verbose, verbose) do
             if task_block
               task_block.call(*[self, task_args].slice(0, task_block.arity))
+            end
+
+            if scheduler_override = task_args[:scheduler]
+              definition.config[:scheduler] = scheduler_override
             end
 
             run_task verbose

--- a/lib/pipely/tasks/deploy.rb
+++ b/lib/pipely/tasks/deploy.rb
@@ -26,12 +26,19 @@ module Pipely
       def initialize(*args, &task_block)
         setup_ivars(args)
 
+        # First non-name parameter allows overriding the configured scheduler.
+        args.unshift(:scheduler)
+
         desc "Deploy pipeline" unless ::Rake.application.last_comment
 
         task name, *args do |_, task_args|
           RakeFileUtils.send(:verbose, verbose) do
             if task_block
               task_block.call(*[self, task_args].slice(0, task_block.arity))
+            end
+
+            if scheduler_override = task_args[:scheduler]
+              definition.config[:scheduler] = scheduler_override
             end
 
             run_task verbose


### PR DESCRIPTION
@dstuebe - this gives us a standard way to override the configured scheduler for any environment for both the `deploy` and `definition` rake tasks.
