### PR TITLE
Loosen fog dependency to ~> 1.23 to reduce conflicts with other gems

### DIFF
--- a/pipely.gemspec
+++ b/pipely.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ruby-graphviz"
   s.add_dependency "rake"
   s.add_dependency "virtus", "~>1.0.0"
-  s.add_dependency "fog", "~>1.23.0"
+  s.add_dependency "fog", "~>1.23"
   s.add_dependency "aws-sdk", "~>1.48"
   s.add_dependency "unf"
   s.add_dependency "activesupport"


### PR DESCRIPTION
@mattgillooly
