### PR TITLE
Sets a pipeline_id on a definition which passes through to the template

### DIFF
--- a/lib/pipely/build/definition.rb
+++ b/lib/pipely/build/definition.rb
@@ -4,6 +4,10 @@ module Pipely
     # Represent a pipeline definition, built from a Template and some config.
     #
     class Definition < Struct.new(:template, :env, :config)
+      extend Forwardable
+
+      def_delegators :template, :pipeline_id=, :pipeline_id
+
       def pipeline_name
         config[:name]
       end

--- a/lib/pipely/build/template.rb
+++ b/lib/pipely/build/template.rb
@@ -12,6 +12,8 @@ module Pipely
     class Template
       include TemplateHelpers
 
+      attr_accessor :pipeline_id
+
       def initialize(source)
         @source = source
         @config = {}

--- a/lib/pipely/tasks/deploy.rb
+++ b/lib/pipely/tasks/deploy.rb
@@ -54,10 +54,11 @@ module Pipely
       def run_task(verbose)
         Rake::Task["upload_steps"].invoke
 
-        Pipely::Deploy::Client.new.deploy_pipeline(
-          definition.pipeline_name,
-          definition.to_json
-        )
+        Pipely::Deploy::Client.new
+          .deploy_pipeline(definition.pipeline_name) do |pipeline_id|
+            definition.pipeline_id = pipeline_id
+            definition.to_json
+          end
       end
 
     end

--- a/spec/lib/pipely/deploy/client_spec.rb
+++ b/spec/lib/pipely/deploy/client_spec.rb
@@ -15,6 +15,7 @@ describe Pipely::Deploy::Client do
 
       subject.should_receive(:create_pipeline).
         with("#{ENV['USER']}:#{pipeline_basename}",
+             nil,
              hash_including( 'basename' => pipeline_basename )
         ).
         and_return(new_pipeline_id)
@@ -44,7 +45,7 @@ describe Pipely::Deploy::Client do
 
       aws.should_receive(:put_pipeline_definition).and_return({})
       aws.should_receive(:activate_pipeline)
-      subject.create_pipeline(pipeline_name) do |pipeline_id|
+      subject.create_pipeline(pipeline_name, nil) do |pipeline_id|
         "Pipeline ID: #{pipeline_id}"
       end
     end

--- a/spec/lib/pipely/deploy/client_spec.rb
+++ b/spec/lib/pipely/deploy/client_spec.rb
@@ -15,7 +15,6 @@ describe Pipely::Deploy::Client do
 
       subject.should_receive(:create_pipeline).
         with("#{ENV['USER']}:#{pipeline_basename}",
-             anything(),
              hash_including( 'basename' => pipeline_basename )
         ).
         and_return(new_pipeline_id)
@@ -24,7 +23,30 @@ describe Pipely::Deploy::Client do
         subject.should_receive(:delete_pipeline).with(id)
       end
 
-      subject.deploy_pipeline(pipeline_basename, definition)
+      subject.deploy_pipeline(pipeline_basename) { definition }
+    end
+  end
+
+  describe '#create_pipeline' do
+    let(:pipeline_name) { 'NewPipeline' }
+    let(:pipeline_id) { 123 }
+    let(:created_pipeline) { double(:created_pipeline, id: pipeline_id) }
+    let(:definition) { "Pipeline ID: 123" }
+
+    let(:data_pipelines) { subject.instance_variable_get(:@data_pipelines) }
+    let(:aws) { subject.instance_variable_get(:@aws) }
+
+    it 'gets the definition from the block' do
+      data_pipelines.stub_chain(:pipelines, :create)
+        .and_return(created_pipeline)
+
+      Pipely::Deploy::JSONDefinition.should_receive(:parse).with(definition)
+
+      aws.should_receive(:put_pipeline_definition).and_return({})
+      aws.should_receive(:activate_pipeline)
+      subject.create_pipeline(pipeline_name) do |pipeline_id|
+        "Pipeline ID: #{pipeline_id}"
+      end
     end
   end
 


### PR DESCRIPTION
@mattgillooly Allows supplying a block to `#deploy_pipeline` and uses it in the deploy rake task.  Passes the pipeline ID through the definition to the template.