### PR TITLE
Downgrading virtus as newer version cause problems with other apps that ...

### DIFF
--- a/lib/pipely/component.rb
+++ b/lib/pipely/component.rb
@@ -28,7 +28,7 @@ module Pipely
       'FAILED' => 'orangered',
     }
 
-    include Virtus.model
+    include Virtus
 
     attribute :id, String
     attribute :type, String

--- a/pipely.gemspec
+++ b/pipely.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "ruby-graphviz"
   s.add_dependency "rake"
-  s.add_dependency "virtus", "~>1.0.0"
+  s.add_dependency "virtus", "~>0.5.5"
   s.add_dependency "fog", "~>1.23"
   s.add_dependency "aws-sdk", "~>1.48"
   s.add_dependency "unf"


### PR DESCRIPTION
...depend on this

@mattgillooly, please review.

Context:
We have quite a few gems which depend upon Virtus 0.5.5. It feels simpler to temporarily downgrade this rather than try to upgrade all of them.
