### PR TITLE
Make sure the time string is properly formatted

### DIFF
--- a/lib/pipely/build/daily_scheduler.rb
+++ b/lib/pipely/build/daily_scheduler.rb
@@ -7,7 +7,7 @@ module Pipely
     class DailyScheduler
 
       def initialize(start_time)
-        @start_time = start_time
+        @start_time = DateTime.parse(start_time).strftime('%H:%M:%S')
       end
 
       def period

--- a/spec/lib/pipely/build/daily_scheduler_spec.rb
+++ b/spec/lib/pipely/build/daily_scheduler_spec.rb
@@ -1,9 +1,8 @@
 require 'pipely/build/daily_scheduler'
-
+require 'timecop'
 describe Pipely::Build::DailyScheduler do
 
   let(:start_time) { "11:00:00" }
-
   subject { described_class.new(start_time) }
 
   describe "#period" do
@@ -12,22 +11,41 @@ describe Pipely::Build::DailyScheduler do
     end
   end
 
+  context "if the start time is garbage" do
+    let(:start_time) { "0ksnsnk" }
+    it 'Raises an error' do
+      expect {described_class.new(start_time)}.to raise_exception ArgumentError
+    end
+  end
+
   describe "#start_date_time" do
-    context "if the start time has already happened today in UTC" do
-      it "chooses the start time tomorrow" do
-        Timecop.freeze(Time.utc(2013, 6, 12, 16, 12, 30)) do
-          expect(subject.start_date_time).to eq("2013-06-13T11:00:00")
+    context "if the start time is 11:00:00 UTC" do
+      let(:start_time) { "11:00:00" }
+      it "and it is after that it chooses the start time tomorrow" do
+        Timecop.freeze(Time.utc(2013, 6, 13, 16, 12, 30)) do
+          expect(subject.start_date_time).to eq("2013-06-14T11:00:00")
         end
       end
-    end
 
-    context "if the start time has not happened yet today in UTC" do
-      it "chooses the start time today" do
+      it "and it is before that it chooses the start time today" do
         Timecop.freeze(Time.utc(2013, 6, 13, 4, 12, 30)) do
           expect(subject.start_date_time).to eq("2013-06-13T11:00:00")
         end
       end
     end
-  end
 
+    context "if the start time has is badly formatted" do
+      let(:start_time) { "9:00:" }
+      it "chooses the start time today" do
+        Timecop.freeze(Time.utc(2013, 6, 13, 4, 12, 30)) do
+          expect(subject.start_date_time).to eq("2013-06-13T09:00:00")
+        end
+      end
+      it "chooses the start time tomorrow" do
+        Timecop.freeze(Time.utc(2013, 6, 13, 11, 12, 30)) do
+          expect(subject.start_date_time).to eq("2013-06-14T09:00:00")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
@mattgillooly @mguymon 
Fix start time comparison in Daily Scheduler to handle formatting errors clearly in the config file.

This bit us on daily email pipeline.

Keeping comparison of string, but ensuring correct formatting using DateTime parse during initialization seems like a reasonable way forward.